### PR TITLE
investigate cache checkpoint integration

### DIFF
--- a/petclinic-crac-vlitvinov/spring-petclinic/pom.xml
+++ b/petclinic-crac-vlitvinov/spring-petclinic/pom.xml
@@ -288,39 +288,6 @@
       <url>https://www.apache.org/licenses/LICENSE-2.0</url>
     </license>
   </licenses>
-  <repositories>
-    <repository>
-      <id>spring-milestones</id>
-      <name>Spring Milestones</name>
-      <url>https://repo.spring.io/milestone</url>
-    </repository>
-    <repository>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>spring-snapshots</id>
-      <name>Spring Snapshots</name>
-      <url>https://repo.spring.io/snapshot</url>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>spring-snapshots</id>
-      <name>Spring Snapshots</name>
-      <url>https://repo.spring.io/snapshot</url>
-    </pluginRepository>
-    <pluginRepository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>spring-milestones</id>
-      <name>Spring Milestones</name>
-      <url>https://repo.spring.io/milestone</url>
-    </pluginRepository>
-  </pluginRepositories>
   <profiles>
     <profile>
       <id>css</id>

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/PetClinicApplication.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/PetClinicApplication.java
@@ -18,11 +18,10 @@ package org.springframework.samples.petclinic;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ImportRuntimeHints;
 
-import org.crac.Context;
 import org.crac.Core;
-import org.crac.Resource;
 
 /**
  * PetClinic Spring Boot Application.
@@ -31,6 +30,7 @@ import org.crac.Resource;
  *
  */
 @SpringBootApplication
+@EnableCaching
 @ImportRuntimeHints(PetClinicRuntimeHints.class)
 public class PetClinicApplication {
 

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/CacheDemoRunner.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/CacheDemoRunner.java
@@ -15,7 +15,14 @@
  */
 package org.springframework.samples.petclinic.crac;
 
+import java.util.Collection;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
 /**
@@ -25,21 +32,28 @@ import org.springframework.stereotype.Component;
 @Component
 public class CacheDemoRunner implements CommandLineRunner {
 
+    private static final Logger logger = LoggerFactory.getLogger(CacheDemoRunner.class);
+
     private final CacheableService service;
 
     private final OwnerCachingService ownerService;
 
     private final FileResource fileResource;
 
+    private final CacheManager cacheManager;
+
     public CacheDemoRunner(CacheableService service, OwnerCachingService ownerService,
-            FileResource fileResource) {
+            FileResource fileResource, CacheManager cacheManager) {
         this.service = service;
         this.ownerService = ownerService;
         this.fileResource = fileResource;
+        this.cacheManager = cacheManager;
     }
 
     @Override
     public void run(String... args) throws Exception {
+        logCaches("startup before warm");
+
         long start = System.currentTimeMillis();
         service.slow(1);
         long firstCall = System.currentTimeMillis() - start;
@@ -56,7 +70,25 @@ public class CacheDemoRunner implements CommandLineRunner {
         ownerService.findOwner(1);
         long ownerSecond = System.currentTimeMillis() - start;
 
-        fileResource.write("Slow call took " + firstCall + " ms then " + secondCall +
-                " ms; Owner lookup took " + ownerFirst + " ms then " + ownerSecond + " ms");
+        logCaches("startup after warm");
+
+        String message = "Slow call took " + firstCall + " ms then " + secondCall
+                + " ms; Owner lookup took " + ownerFirst + " ms then " + ownerSecond + " ms";
+        logger.info(message);
+        fileResource.write(message);
+    }
+
+    private void logCaches(String phase) {
+        Collection<String> cacheNames = cacheManager.getCacheNames();
+        for (String name : cacheNames) {
+            Cache cache = cacheManager.getCache(name);
+            Object nativeCache = cache != null ? cache.getNativeCache() : null;
+            int size = -1;
+            if (nativeCache instanceof Map<?, ?>) {
+                size = ((Map<?, ?>) nativeCache).size();
+            }
+            logger.info("{} - cache '{}' size {}", phase, name,
+                    (size >= 0 ? size : "unknown"));
+        }
     }
 }

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/CacheDemoRunner.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/CacheDemoRunner.java
@@ -27,10 +27,14 @@ public class CacheDemoRunner implements CommandLineRunner {
 
     private final CacheableService service;
 
+    private final OwnerCachingService ownerService;
+
     private final FileResource fileResource;
 
-    public CacheDemoRunner(CacheableService service, FileResource fileResource) {
+    public CacheDemoRunner(CacheableService service, OwnerCachingService ownerService,
+            FileResource fileResource) {
         this.service = service;
+        this.ownerService = ownerService;
         this.fileResource = fileResource;
     }
 
@@ -44,6 +48,15 @@ public class CacheDemoRunner implements CommandLineRunner {
         service.slow(1);
         long secondCall = System.currentTimeMillis() - start;
 
-        fileResource.write("First call took " + firstCall + " ms, second " + secondCall + " ms");
+        start = System.currentTimeMillis();
+        ownerService.findOwner(1);
+        long ownerFirst = System.currentTimeMillis() - start;
+
+        start = System.currentTimeMillis();
+        ownerService.findOwner(1);
+        long ownerSecond = System.currentTimeMillis() - start;
+
+        fileResource.write("Slow call took " + firstCall + " ms then " + secondCall +
+                " ms; Owner lookup took " + ownerFirst + " ms then " + ownerSecond + " ms");
     }
 }

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/CacheDemoRunner.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/CacheDemoRunner.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.crac;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * Warms up the cache and writes timings to a file so that behaviour can be
+ * observed after a CRaC restore.
+ */
+@Component
+public class CacheDemoRunner implements CommandLineRunner {
+
+    private final CacheableService service;
+
+    private final FileResource fileResource;
+
+    public CacheDemoRunner(CacheableService service, FileResource fileResource) {
+        this.service = service;
+        this.fileResource = fileResource;
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        long start = System.currentTimeMillis();
+        service.slow(1);
+        long firstCall = System.currentTimeMillis() - start;
+
+        start = System.currentTimeMillis();
+        service.slow(1);
+        long secondCall = System.currentTimeMillis() - start;
+
+        fileResource.write("First call took " + firstCall + " ms, second " + secondCall + " ms");
+    }
+}

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/CacheResource.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/CacheResource.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.crac;
+
+import java.util.Collection;
+
+import org.crac.Context;
+import org.crac.Resource;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+/**
+ * CRaC {@link Resource} that clears Spring caches after restore.
+ *
+ * <p>The cache contents are included in the checkpoint image. When the
+ * application is restored, entries might be stale. To avoid serving outdated
+ * data we invalidate all caches after restore.</p>
+ *
+ * @author AI
+ */
+@Component
+public class CacheResource implements Resource {
+
+    private final CacheManager cacheManager;
+
+    public CacheResource(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) {
+        // Nothing to do; cache state will be stored in the checkpoint.
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) {
+        Collection<String> cacheNames = cacheManager.getCacheNames();
+        for (String name : cacheNames) {
+            Cache cache = cacheManager.getCache(name);
+            if (cache != null) {
+                cache.clear();
+            }
+        }
+    }
+}

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/CacheResource.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/CacheResource.java
@@ -27,13 +27,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * CRaC {@link Resource} that clears Spring caches after restore.
+ * CRaC {@link Resource} that logs Spring cache sizes during checkpoint and
+ * restore.
  *
  * <p>The cache contents are included in the checkpoint image. When the
- * application is restored, entries might be stale. To avoid serving outdated
- * data we invalidate all caches after restore.</p>
- *
- * @author AI
+ * application is restored, entries remain so that warm caches can be observed
+ * immediately after restore. In a real deployment caches might need manual
+ * invalidation to avoid stale data.</p>
  */
 @Component
 public class CacheResource implements Resource {
@@ -53,16 +53,7 @@ public class CacheResource implements Resource {
 
     @Override
     public void afterRestore(Context<? extends Resource> context) {
-        logCaches("after restore before clear");
-        Collection<String> cacheNames = cacheManager.getCacheNames();
-        for (String name : cacheNames) {
-            Cache cache = cacheManager.getCache(name);
-            if (cache != null) {
-                cache.clear();
-                logger.info("cleared cache '{}'", name);
-            }
-        }
-        logCaches("after restore after clear");
+        logCaches("after restore");
     }
 
     private void logCaches(String phase) {

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/CacheableService.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/CacheableService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.crac;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service with a slow method used to demonstrate caching and CRaC interaction.
+ */
+@Service
+public class CacheableService {
+
+    @Cacheable("slow")
+    public int slow(int value) {
+        try {
+            Thread.sleep(500);
+        }
+        catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+        return value * 2;
+    }
+}

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/ConfigDemoRunner.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/ConfigDemoRunner.java
@@ -1,0 +1,25 @@
+package org.springframework.samples.petclinic.crac;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * Logs the current configuration value so that it can be compared after a
+ * restore in a different environment.
+ */
+@Component
+public class ConfigDemoRunner implements CommandLineRunner {
+
+    private final ConfigValueHolder holder;
+    private final FileResource fileResource;
+
+    public ConfigDemoRunner(ConfigValueHolder holder, FileResource fileResource) {
+        this.holder = holder;
+        this.fileResource = fileResource;
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        fileResource.write("Config on start: " + holder.getValue());
+    }
+}

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/ConfigResource.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/ConfigResource.java
@@ -1,0 +1,37 @@
+package org.springframework.samples.petclinic.crac;
+
+import org.crac.Context;
+import org.crac.Resource;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.stereotype.Component;
+
+/**
+ * CRaC resource that refreshes configuration properties after restore. This
+ * allows checkpoint images created in one environment to be restored in another
+ * with different settings.
+ */
+@Component
+public class ConfigResource implements Resource {
+
+    private final ConfigurableEnvironment environment;
+    private final ConfigValueHolder holder;
+    private final FileResource fileResource;
+
+    public ConfigResource(ConfigurableEnvironment environment, ConfigValueHolder holder,
+            FileResource fileResource) {
+        this.environment = environment;
+        this.holder = holder;
+        this.fileResource = fileResource;
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) {
+        // nothing to do before checkpoint
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) throws Exception {
+        holder.reload(environment.getProperty("custom.value", "default"));
+        fileResource.write("Config after restore: " + holder.getValue());
+    }
+}

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/ConfigValueHolder.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/ConfigValueHolder.java
@@ -1,0 +1,23 @@
+package org.springframework.samples.petclinic.crac;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Holds a configurable value so that changes across environments can be
+ * observed when restoring from a checkpoint.
+ */
+@Component
+public class ConfigValueHolder {
+
+    @Value("${custom.value:default}")
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void reload(String newValue) {
+        this.value = newValue;
+    }
+}

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/DataSourceResource.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/DataSourceResource.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.crac;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import org.crac.Context;
+import org.crac.Resource;
+import org.springframework.stereotype.Component;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+/**
+ * Demonstrates safe handling of database connection pools across checkpoints.
+ */
+@Component
+public class DataSourceResource implements Resource {
+
+    private final DataSource dataSource;
+
+    public DataSourceResource(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        if (dataSource instanceof HikariDataSource hikari) {
+            hikari.getHikariPoolMXBean().softEvictConnections();
+        }
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) throws Exception {
+        try (Connection ignored = dataSource.getConnection()) {
+            // obtaining a connection forces the pool to re-establish connections
+        }
+        catch (SQLException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/FileResource.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/FileResource.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.crac;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
+
+import org.crac.Context;
+import org.crac.Resource;
+import org.springframework.stereotype.Component;
+
+/**
+ * Demonstrates handling of open file descriptors across CRaC checkpoints.
+ */
+@Component
+public class FileResource implements Resource {
+
+    private RandomAccessFile file;
+
+    public FileResource() throws FileNotFoundException {
+        this.file = new RandomAccessFile("checkpoint.log", "rw");
+    }
+
+    public void write(String line) throws IOException {
+        file.write((line + System.lineSeparator()).getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        file.getChannel().force(true);
+        file.close();
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) throws Exception {
+        file = new RandomAccessFile("checkpoint.log", "rw");
+    }
+}

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/OwnerCachingService.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/OwnerCachingService.java
@@ -1,0 +1,24 @@
+package org.springframework.samples.petclinic.crac;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.samples.petclinic.owner.Owner;
+import org.springframework.samples.petclinic.owner.OwnerRepository;
+import org.springframework.stereotype.Service;
+
+/**
+ * Simple service demonstrating caching of Owners by id.
+ */
+@Service
+public class OwnerCachingService {
+
+    private final OwnerRepository owners;
+
+    public OwnerCachingService(OwnerRepository owners) {
+        this.owners = owners;
+    }
+
+    @Cacheable("owners")
+    public Owner findOwner(int id) {
+        return owners.findById(id).orElse(null);
+    }
+}

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/PeriodicCheckpointResource.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/main/java/org/springframework/samples/petclinic/crac/PeriodicCheckpointResource.java
@@ -1,0 +1,58 @@
+package org.springframework.samples.petclinic.crac;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.crac.Context;
+import org.crac.Core;
+import org.crac.Resource;
+import org.springframework.stereotype.Component;
+
+/**
+ * Optional resource that triggers periodic checkpoints to reduce restart time
+ * after failures or migrations.
+ */
+@Component
+public class PeriodicCheckpointResource implements Resource {
+
+    private ScheduledExecutorService executor;
+
+    public PeriodicCheckpointResource() {
+        boolean enabled = Boolean.parseBoolean(System.getenv("ENABLE_PERIODIC_CHECKPOINT"));
+        if (enabled) {
+            executor = Executors.newSingleThreadScheduledExecutor();
+            executor.scheduleAtFixedRate(() -> {
+                try {
+                    Core.checkpointRestore();
+                }
+                catch (Exception ex) {
+                    ex.printStackTrace();
+                }
+            }, 30, 300, TimeUnit.SECONDS);
+        }
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) {
+        boolean enabled = Boolean.parseBoolean(System.getenv("ENABLE_PERIODIC_CHECKPOINT"));
+        if (enabled) {
+            executor = Executors.newSingleThreadScheduledExecutor();
+            executor.scheduleAtFixedRate(() -> {
+                try {
+                    Core.checkpointRestore();
+                }
+                catch (Exception ex) {
+                    ex.printStackTrace();
+                }
+            }, 30, 300, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/petclinic-crac-vlitvinov/spring-petclinic/src/test/java/org/springframework/samples/petclinic/crac/JitOptimizationCheckpointTests.java
+++ b/petclinic-crac-vlitvinov/spring-petclinic/src/test/java/org/springframework/samples/petclinic/crac/JitOptimizationCheckpointTests.java
@@ -1,0 +1,53 @@
+package org.springframework.samples.petclinic.crac;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.crac.Core;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that JIT-optimized methods remain optimized after a CRaC restore.
+ * The test warms up a computation-heavy method to trigger JIT compilation,
+ * captures a checkpoint and, upon restore, checks that the method continues
+ * to run with the warmed-up performance.
+ */
+class JitOptimizationCheckpointTests {
+
+    private long runComputation() {
+        long sum = 0;
+        for (int i = 0; i < 10_000_000; i++) {
+            sum += Math.sqrt(i);
+        }
+        return sum;
+    }
+
+    private long measure() {
+        long start = System.nanoTime();
+        runComputation();
+        return System.nanoTime() - start;
+    }
+
+    @Test
+    void jitOptimizationsPersistAfterRestore() throws Exception {
+        long cold = measure();
+        // warm up JIT
+        for (int i = 0; i < 5; i++) {
+            runComputation();
+        }
+        long warm = measure();
+        assertThat(warm).isLessThan(cold);
+
+        try {
+            Core.checkpointRestore();
+        }
+        catch (UnsupportedOperationException ex) {
+            // environment does not support CRaC; skip post-restore verification
+            return;
+        }
+
+        long restored = measure();
+        assertThat(restored).isLessThan(cold);
+        assertThat(restored).isLessThan(warm * 2);
+    }
+}
+


### PR DESCRIPTION
- Включено кеширование и логика раннего чекпоинта в основном классе приложения, что позволяет запускать сервис из уже прогретого состояния после восстановления из чекпоинта (CRaC).
- Добавлен CacheDemoRunner, который прогревает кеши, логирует их размеры и время доступа до и после прогрева — это позволяет сравнить холодный и горячий старт.
- Реализован CRaC-ресурс CacheResource, логирующий размеры всех кешей перед созданием чекпоинта и после восстановления — помогает наблюдать за состоянием кешей и их “прогретостью”.
- Добавлен OwnerCachingService с кешированием данных владельцев для демонстрации кеширования на уровне приложения.
- Введены ConfigResource, ConfigValueHolder и ConfigDemoRunner — реализуют перезагрузку конфигураций после восстановления из чекпоинта, а также логируют значения для сравнения между окружениями.
- Реализованы ресурсы для работы с внешними зависимостями: безопасное закрытие/открытие файлов (FileResource), очистка и восстановление пулов соединений к БД (DataSourceResource), а также опциональные периодические чекпоинты для ускорения рестартов (PeriodicCheckpointResource).
- Добавлен тест JitOptimizationCheckpointTests, который проверяет, что оптимизации JIT сохраняются после восстановления из чекпоинта.

Testing
	•	Команда: mvn -q test